### PR TITLE
Make e2e test use `verify_subject_alt_name`

### DIFF
--- a/e2e/create_config.sh
+++ b/e2e/create_config.sh
@@ -19,7 +19,6 @@ static_resources:
       socket_address: { address: 127.0.0.1, port_value: 10000 }
     filter_chains:
     - filters:
-      - name: io.solo.client_certificate_restriction
       - name: envoy.http_connection_manager
         config:
           stat_prefix: http
@@ -47,6 +46,7 @@ static_resources:
           validation_context:
             trusted_ca:
               filename: /tmp/pki/root/certs/root.crt
+            verify_subject_alt_name: [ "wiki.umbrella.com" ]
   clusters:
   - connect_timeout: 5.000s
     hosts:

--- a/e2e/e2e_test.py
+++ b/e2e/e2e_test.py
@@ -69,7 +69,7 @@ class ClientCertificateRestrictionTestCase(unittest.TestCase):
     response = requests.get(
       'https://localhost:10000/get',
       verify=False,
-      cert=('/tmp/pki/root/certs/bob@acme.com.crt', '/tmp/pki/root/keys/bob@acme.com.key'))
+      cert=('/tmp/pki/root/certs/www.umbrella.com.crt', '/tmp/pki/root/keys/www.umbrella.com.key'))
     self.assertEqual(httplib.OK, response.status_code)
 
     # Make an invalid request.


### PR DESCRIPTION
This is a PoC of using Envoy's built-in DNS SAN configuration.
The client certificate was created using the following command line:
```bash
easypki create --ca-name root --dns "www.umbrella.com" --dns "wiki.umbrella.com"  www.umbrella.com
```