### PR TITLE
Make filter use Authorize REST API

### DIFF
--- a/e2e/authorize_endpoint.py
+++ b/e2e/authorize_endpoint.py
@@ -25,7 +25,7 @@ class _Handler(BaseHTTPServer.BaseHTTPRequestHandler):
     }
 
   def do_POST(self):
-    assert (self.path == '/agent/connect/authorize')
+    assert (self.path == '/v1/agent/connect/authorize')
 
     self.send_response(200)
     self.send_header('Content-type','application/json')
@@ -39,7 +39,7 @@ class _Handler(BaseHTTPServer.BaseHTTPRequestHandler):
 
 def _start_endpoint():
   host_name = ""
-  port_number = 4223
+  port_number = 8501
   httpd = BaseHTTPServer.HTTPServer((host_name, port_number), _Handler)
   httpd.serve_forever()
 

--- a/source/extensions/filters/network/client_certificate_restriction/BUILD
+++ b/source/extensions/filters/network/client_certificate_restriction/BUILD
@@ -24,7 +24,9 @@ envoy_cc_library(
         "@envoy//include/envoy/upstream:cluster_manager_interface",
         "@envoy//source/common/common:assert_lib",
         "@envoy//source/common/common:logger_lib",
+        "@envoy//source/common/http:message_lib",
         "@envoy//source/common/ssl:ssl_socket_lib",
+        "@solo_envoy_common//source/common/buffer:buffer_utility_lib",
     ],
 )
 


### PR DESCRIPTION
1. Prepend "/v1/" to the Authorize endpoint path.
2. Change the mock Authorize endpoint port to 8501.
3. Modify the e2e test so that the target name is "db" and the client
   name is "web".
   This convention matches the sample Authorize payload as appears in
   Consul Connect's documentation.
4. Make the e2e test launch a mock authorize endpoint.
5. Make the filter's `onEvent()` initiate a REST request using the
   Authorize API.