### PR TITLE
Introduce `ConsulConnect::Config::stats()`

### DIFF
--- a/source/extensions/filters/network/consul_connect/config.cc
+++ b/source/extensions/filters/network/consul_connect/config.cc
@@ -15,7 +15,7 @@ Network::FilterFactoryCb ConfigFactory::createFilterFactoryFromProtoTyped(
     Server::Configuration::FactoryContext &context) {
   ASSERT(!proto_config.target().empty());
 
-  ConfigSharedPtr filter_config(new Config(proto_config));
+  ConfigSharedPtr filter_config(new Config(proto_config, context.scope()));
   return [&context,
           filter_config](Network::FilterManager &filter_manager) -> void {
     filter_manager.addReadFilter(

--- a/source/extensions/filters/network/consul_connect/consul_connect.cc
+++ b/source/extensions/filters/network/consul_connect/consul_connect.cc
@@ -20,12 +20,20 @@ const std::string Filter::AUTHORIZE_PATH = "/v1/agent/connect/authorize";
 
 Config::Config(
     const envoy::config::filter::network::consul_connect::v2::ConsulConnect
-        &config)
+        &config,
+    Stats::Scope &scope)
     : target_(config.target()),
       authorize_hostname_(config.authorize_hostname()),
       authorize_cluster_name_(config.authorize_cluster_name()),
       request_timeout_(
-          PROTOBUF_GET_MS_OR_DEFAULT(config, request_timeout, 1000)) {}
+          PROTOBUF_GET_MS_OR_DEFAULT(config, request_timeout, 1000)),
+      stats_(generateStats(scope)) {}
+
+InstanceStats Config::generateStats(Stats::Scope &scope) {
+  const std::string final_prefix{"consul_connect."};
+  return {ALL_CONSUL_CONNECT_FILTER_STATS(
+      POOL_COUNTER_PREFIX(scope, final_prefix))};
+}
 
 Filter::Filter(ConfigSharedPtr config, Upstream::ClusterManager &cm)
     : config_(config), cm_(cm) {}

--- a/source/extensions/filters/network/consul_connect/consul_connect.h
+++ b/source/extensions/filters/network/consul_connect/consul_connect.h
@@ -4,6 +4,7 @@
 
 #include "envoy/network/connection.h"
 #include "envoy/network/filter.h"
+#include "envoy/stats/stats_macros.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/buffer/buffer_utility.h"
@@ -17,23 +18,44 @@ namespace NetworkFilters {
 namespace ConsulConnect {
 
 /**
+ * All stats for the Consul Connect filter. @see stats_macros.h
+ */
+// clang-format off
+#define ALL_CONSUL_CONNECT_FILTER_STATS(COUNTER)                                                   \
+  COUNTER(allowed)                                                                                 \
+  COUNTER(denied)
+// clang-format on
+
+/**
+ * Wrapper struct for Consul Connect filter stats. @see stats_macros.h
+ */
+struct InstanceStats {
+  ALL_CONSUL_CONNECT_FILTER_STATS(GENERATE_COUNTER_STRUCT)
+};
+
+/**
  * Global configuration for Consul Connect.
  */
 class Config {
 public:
   Config(const envoy::config::filter::network::consul_connect::v2::ConsulConnect
-             &config);
+             &config,
+         Stats::Scope &scope);
 
   const std::string &target() { return target_; }
   const std::string &authorizeHostname() { return authorize_hostname_; }
   const std::string &authorizeClusterName() { return authorize_cluster_name_; }
   const std::chrono::milliseconds &requestTimeout() { return request_timeout_; }
+  InstanceStats &stats() { return stats_; }
 
 private:
+  static InstanceStats generateStats(Stats::Scope &scope);
+
   const std::string target_;
   const std::string authorize_hostname_;
   const std::string authorize_cluster_name_;
   const std::chrono::milliseconds request_timeout_;
+  InstanceStats stats_;
 };
 
 typedef std::shared_ptr<Config> ConfigSharedPtr;

--- a/test/extensions/filters/network/consul_connect/BUILD
+++ b/test/extensions/filters/network/consul_connect/BUILD
@@ -19,5 +19,6 @@ envoy_cc_test(
     deps = [
         "//:authorize_proto_cc",
         "//source/extensions/filters/network/consul_connect",
+        "@envoy//test/mocks/server:server_mocks",
     ],
 )

--- a/test/extensions/filters/network/consul_connect/consul_connect_test.cc
+++ b/test/extensions/filters/network/consul_connect/consul_connect_test.cc
@@ -1,8 +1,13 @@
 #include "common/protobuf/utility.h"
 
+#include "test/mocks/server/mocks.h"
+
 #include "authorize.pb.h"
 #include "extensions/filters/network/consul_connect/consul_connect.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+
+using testing::NiceMock;
 
 namespace Envoy {
 namespace Extensions {
@@ -18,11 +23,14 @@ TEST(ConsulConnectConfigTest, Constructor) {
   proto_config.set_authorize_cluster_name("authorize");
   proto_config.mutable_request_timeout()->set_seconds(6);
 
-  Config config(proto_config);
+  NiceMock<Server::Configuration::MockFactoryContext> context;
+  Config config(proto_config, context.scope());
   EXPECT_EQ("target", config.target());
   EXPECT_EQ("example.com", config.authorizeHostname());
   EXPECT_EQ("authorize", config.authorizeClusterName());
   EXPECT_EQ(std::chrono::milliseconds(6000), config.requestTimeout());
+  EXPECT_EQ(0U, config.stats().allowed_.value());
+  EXPECT_EQ(0U, config.stats().denied_.value());
 }
 
 TEST(ConsulConnectTest, AuthorizePayloadProto) {


### PR DESCRIPTION
1. Introduce struct `ConsulConnect::InstanceStats`.
2. Introduce `Config::stats()` to access the `InstanceStats`.
3. Add very basic stats coverage to `ConsulConnectConfigTest`.